### PR TITLE
Harden directory permissions and fix test failure

### DIFF
--- a/duckserver/duckserver.go
+++ b/duckserver/duckserver.go
@@ -303,7 +303,7 @@ func (srv *Server) connectDuckDB(ctx context.Context) (*sql.DB, *sql.Conn, error
 	// Compose duckdbinit.Settings
 	settings := srv.dbSettings
 	if srv.dbSharedDir != "" {
-		if err := os.MkdirAll(srv.dbSharedDir, 0777); err != nil {
+		if err := os.MkdirAll(srv.dbSharedDir, 0750); err != nil {
 			return nil, nil, err
 		}
 		settings.AllowedDirectories = append(settings.AllowedDirectories, srv.dbSharedDir)
@@ -358,7 +358,7 @@ func (srv *Server) getPrivateDir(ctx context.Context, makeDir bool) (string, err
 	}
 	privateDir := filepath.Join(srv.dbPrivateRoot, connID.String())
 	if makeDir {
-		if err := os.MkdirAll(privateDir, 0777); err != nil {
+		if err := os.MkdirAll(privateDir, 0700); err != nil {
 			return "", err
 		}
 	}

--- a/duckserver/duckserver_test.go
+++ b/duckserver/duckserver_test.go
@@ -560,6 +560,7 @@ func TestGetConfigJSON(t *testing.T) {
 	}
 	want := `{
   "EnableDebugLog": false,
+  "EnablePprof": false,
   "Address": "127.0.0.1:0",
   "MaxDB": 4,
   "PIDFile": "",


### PR DESCRIPTION
Restricted permissions for shared and private directories created by the server to improve security. Shared directories now use 0750 and private directories use 0700. Additionally, fixed a pre-existing test failure in `TestGetConfigJSON` where the `EnablePprof` field was missing from the expected JSON output.

---
*PR created automatically by Jules for task [475408158560819476](https://jules.google.com/task/475408158560819476) started by @koron*